### PR TITLE
Mention new function for some deprecations.

### DIFF
--- a/src/git/object_.d
+++ b/src/git/object_.d
@@ -89,8 +89,8 @@ GitObject lookupObject(GitRepo repo, in char[] hexString, GitType type = GitType
     }
 }
 
-deprecated alias lookup = lookupObject;
-deprecated alias lookupByPrefix = lookupObjectPrefix;
+deprecated("Please use lookupObject instead.") alias lookup = lookupObject;
+deprecated("Please use lookupObjectPrefix instead.") alias lookupByPrefix = lookupObjectPrefix;
 
 ///
 const(char)[] toString(GitType type)

--- a/src/git/repository.d
+++ b/src/git/repository.d
@@ -233,7 +233,7 @@ struct GitRepo
         If $(D path) does not exist or if the .git directory is not
         found in $(D path), a $(D GitException) is thrown.
      */
-    deprecated this(in char[] path)
+    deprecated("Please use openRepository instead.") this(in char[] path)
     {
         git_repository* repo;
         require(git_repository_open(&repo, path.gitStr) == 0);


### PR DESCRIPTION
Trivial, and probably I was the only one using them anyway, but it took me a while to figure out where the `GitRepo` constructor went, so I added some messages.
